### PR TITLE
Create jobs for devices for notifications

### DIFF
--- a/app/jobs/announcement_job.rb
+++ b/app/jobs/announcement_job.rb
@@ -3,7 +3,7 @@ class AnnouncementJob < ActiveJob::Base
 
   def perform(announcement)
     Device.all.each_with_index do |device|
-      AnnouncementSender.new(announcement, device.token).run
+      AnnouncementSenderJob.perform_later(announcement, device)
     end
 
     announcement.update(sent: true)

--- a/app/jobs/announcement_sender_job.rb
+++ b/app/jobs/announcement_sender_job.rb
@@ -1,0 +1,7 @@
+class AnnouncementSenderJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(announcement, device)
+    AnnouncementSender.new(announcement, device.token).run
+  end
+end

--- a/spec/jobs/announcement_job_spec.rb
+++ b/spec/jobs/announcement_job_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 describe AnnouncementJob, type: :job do
-  it "will invoke AnnouncementSender for devices" do
-    sender = double("Sender", run: nil)
-    allow(AnnouncementSender).to receive(:new).and_return(sender)
+  it "will invoke AnnouncementSenderJob for devices" do
+    allow(AnnouncementSenderJob).to receive(:perform_later)
     devices = create_list(:device, 2)
     announcement = create(:announcement)
     job = AnnouncementJob.new
@@ -11,8 +10,8 @@ describe AnnouncementJob, type: :job do
     job.perform(announcement)
 
     devices.each do |device|
-      expect(AnnouncementSender).
-        to have_received(:new).with(announcement, device.token)
+      expect(AnnouncementSenderJob).
+        to have_received(:perform_later).with(announcement, device)
     end
   end
 

--- a/spec/jobs/announcement_sender_job_spec.rb
+++ b/spec/jobs/announcement_sender_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe AnnouncementSenderJob, type: :job do
+  it "will invoke AnnouncementSender for device" do
+    sender = double("Sender", run: nil)
+    allow(AnnouncementSender).to receive(:new).and_return(sender)
+    device = create(:device)
+    announcement = create(:announcement)
+    job = AnnouncementSenderJob.new
+
+    job.perform(announcement, device)
+
+    expect(AnnouncementSender).
+      to have_received(:new).with(announcement, device.token)
+  end
+end


### PR DESCRIPTION
So we can keep track if a particular device failed in sending notification