### PR TITLE
Support multiple conference

### DIFF
--- a/app/controllers/api/v1/conferences_controller.rb
+++ b/app/controllers/api/v1/conferences_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ConferencesController < ApplicationController
   def index
-    @conferences = Conference.upcoming
+    @conferences = RubyConference.upcoming
   end
 end

--- a/app/controllers/api/v1/devices_controller.rb
+++ b/app/controllers/api/v1/devices_controller.rb
@@ -3,18 +3,18 @@ class Api::V1::DevicesController < ApplicationController
   skip_before_action :verify_authenticity_token, only: :create
 
   def create
-    device = Device.find_or_create_by(token: device_params[:token])
+    creator = DeviceCreator.new(device_params)
 
-    if device.save
+    if creator.create
       head :ok
     else
-      render json: device.errors, status: :unprocessable_entity
+      render json: creator.device.errors, status: :unprocessable_entity
     end
   end
 
   private
 
   def device_params
-    params.require(:device).permit(:token)
+    params.require(:device).permit(:token, :conference_type)
   end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -6,6 +6,7 @@ class Conference < ActiveRecord::Base
   validates :website, presence: true
   validates :start_date, presence: true
   validates :end_date, presence: true
+  validates :type, presence: true
 
   def self.upcoming
     where("start_date >= ?", Date.today).order("start_date")

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -1,3 +1,5 @@
 class Device < ActiveRecord::Base
-  validates :token, presence: true, uniqueness: true
+  validates :token, presence: true, uniqueness: { scope: :conference_type }
+
+  enum conference_type: [:ruby, :js]
 end

--- a/app/models/js_conference.rb
+++ b/app/models/js_conference.rb
@@ -1,0 +1,2 @@
+class JsConference < Conference
+end

--- a/app/models/ruby_conference.rb
+++ b/app/models/ruby_conference.rb
@@ -1,0 +1,2 @@
+class RubyConference < Conference
+end

--- a/app/services/device_creator.rb
+++ b/app/services/device_creator.rb
@@ -1,0 +1,26 @@
+class DeviceCreator
+  attr_reader :device
+
+  def initialize(params)
+    @params = params
+  end
+
+  def create
+    @device ||= Device.find_or_create_by(
+      token: token,
+      conference_type: conference_type
+    )
+  end
+
+  private
+
+  attr_reader :params
+
+  def token
+    params[:token]
+  end
+
+  def conference_type
+    params[:conference_type] || "ruby"
+  end
+end

--- a/app/views/api/v1/conferences/index.json.jbuilder
+++ b/app/views/api/v1/conferences/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array!(@conferences) do |conference|
-  json.partial! conference
+  json.partial! conference.becomes(Conference)
 end

--- a/db/migrate/20150612213117_add_type_to_conferences.rb
+++ b/db/migrate/20150612213117_add_type_to_conferences.rb
@@ -1,0 +1,8 @@
+class AddTypeToConferences < ActiveRecord::Migration
+  def change
+    add_column :conferences, :type, :string, default: "RubyConference"
+
+    change_column :conferences, :type, :string, null: false, index: true
+    change_column_default :conferences, :type, nil
+  end
+end

--- a/db/migrate/20150614163801_add_conference_type_to_devices.rb
+++ b/db/migrate/20150614163801_add_conference_type_to_devices.rb
@@ -1,0 +1,8 @@
+class AddConferenceTypeToDevices < ActiveRecord::Migration
+  def change
+    add_column :devices, :conference_type, :integer, default: 0
+
+    change_column :devices, :conference_type, :integer, null: false, index: true
+    change_column_default :devices, :conference_type, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150605155446) do
+ActiveRecord::Schema.define(version: 20150614163801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20150605155446) do
     t.date     "start_date",       null: false
     t.date     "end_date",         null: false
     t.string   "website",          null: false
+    t.string   "type",             null: false
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -53,9 +54,10 @@ ActiveRecord::Schema.define(version: 20150605155446) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "devices", force: :cascade do |t|
-    t.string   "token",      null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "token",           null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.integer  "conference_type", null: false
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,10 +2,10 @@ require 'net/http'
 require 'uri'
 
 conferences = YAML.load(File.read("#{Rails.root}/db/rubyconferences.yml"))
-Conference.delete_all
+RubyConference.delete_all
 
 conferences.each do |attributes|
-  conference = Conference.new
+  conference = RubyConference.new
   conference.name = attributes["name"]
   conference.location = attributes["location"]
   conference.website = attributes["website"]

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -7,5 +7,11 @@ FactoryGirl.define do
     twitter_username "twiiter"
     image_url "image_url"
     website "foo.bar"
+
+    factory :ruby_conference, class: "RubyConference" do
+    end
+
+    factory :js_conference, class: "JsConference" do
+    end
   end
 end

--- a/spec/factories/devices.rb
+++ b/spec/factories/devices.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :device do
     sequence(:token) { |n| "token-#{n}" }
+    conference_type "ruby"
   end
 end

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -8,18 +8,22 @@ RSpec.describe Conference, :type => :model do
   it { should validate_presence_of(:website) }
   it { should validate_presence_of(:start_date) }
   it { should validate_presence_of(:end_date) }
+  it { should validate_presence_of(:type) }
 
   describe ".upcoming" do
     it "returns upcoming Conferences based on start date" do
-      create(:conference, start_date: Date.yesterday)
-      later_conference = create(:conference, start_date: Date.today)
+      create(:ruby_conference, start_date: Date.yesterday)
+      later_conference = create(:ruby_conference, start_date: Date.today)
 
       expect(Conference.upcoming).to eq([later_conference])
     end
 
     it "orders Conferences based on start date" do
-      todays_conference = create(:conference, start_date: Date.today)
-      later_conference = create(:conference, start_date: Date.today + 1.day)
+      todays_conference = create(:ruby_conference, start_date: Date.today)
+      later_conference = create(
+        :ruby_conference,
+        start_date: Date.today + 1.day
+      )
 
       expect(Conference.upcoming).to eq([todays_conference, later_conference])
     end
@@ -27,15 +31,18 @@ RSpec.describe Conference, :type => :model do
 
   describe ".past" do
     it "returns past Conferences based on start date" do
-      old_conference = create(:conference, start_date: Date.yesterday)
-      create(:conference, start_date: Date.today)
+      old_conference = create(:ruby_conference, start_date: Date.yesterday)
+      create(:ruby_conference, start_date: Date.today)
 
       expect(Conference.past).to eq([old_conference])
     end
 
     it "orders Conferences based on start date" do
-      old_conference = create(:conference, start_date: Date.yesterday)
-      very_old_conference = create(:conference, start_date: Date.yesterday - 10.day)
+      old_conference = create(:ruby_conference, start_date: Date.yesterday)
+      very_old_conference = create(
+        :ruby_conference,
+        start_date: Date.yesterday - 10.day
+      )
 
       expect(Conference.past).to eq([old_conference, very_old_conference])
     end

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -1,5 +1,43 @@
 require 'rails_helper'
 
-RSpec.describe Device, :type => :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Device, type: :model do
+  describe "validations" do
+    describe "token" do
+      it { should validate_presence_of(:token) }
+
+      it "will not create device with same token and conference_type" do
+        token = "same-token"
+        ruby_conference_type = "ruby"
+        create(:device, token: token, conference_type: ruby_conference_type)
+        device = build(
+          :device,
+          token: token,
+          conference_type: ruby_conference_type
+        )
+
+        expect(device).not_to be_valid
+      end
+
+      it "will allow to use same token with different conference_type" do
+        token = "same-token"
+        ruby_conference_type = "ruby"
+        js_conference_type = "js"
+        create(:device, token: token, conference_type: ruby_conference_type)
+        device = build(
+          :device,
+          token: token,
+          conference_type: js_conference_type
+        )
+
+        expect(device).to be_valid
+      end
+    end
+  end
+
+  describe "conference_type" do
+    it "has ruby and js as an option" do
+      expect(Device.conference_types["ruby"]).to eq(0)
+      expect(Device.conference_types["js"]).to eq(1)
+    end
+  end
 end

--- a/spec/services/device_creator_spec.rb
+++ b/spec/services/device_creator_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+describe DeviceCreator do
+  describe "#create" do
+    context "when params are given" do
+      context "when device already exists" do
+        it "will not create a new device" do
+          device = create(:device)
+          params = {
+            token: device.token,
+            conference_type: device.conference_type
+          }
+          creator = DeviceCreator.new(params)
+
+          creator.create
+
+          expect(Device.count).to eq(1)
+        end
+      end
+
+      context "when no device exists" do
+        it "will create a device" do
+          token = "something"
+          conference_type = "ruby"
+          params = {
+            token: token,
+            conference_type: conference_type
+          }
+          creator = DeviceCreator.new(params)
+
+          creator.create
+
+          expect(Device.count).to eq(1)
+          device = Device.last
+          expect(device.token).to eq(token)
+          expect(device.conference_type).to eq(conference_type)
+        end
+      end
+    end
+
+    context "when params are missing" do
+      context "when conference_type is missing" do
+        context "when device exists in system" do
+          it "will not create a new device" do
+            device = create(:device)
+            params = {
+              token: device.token,
+              conference_type: nil
+            }
+            creator = DeviceCreator.new(params)
+
+            creator.create
+
+            expect(Device.count).to eq(1)
+          end
+        end
+
+        context "when no device exists" do
+          it "will create a new device with conference_type as ruby" do
+            token = "some-token"
+            params = {
+              token: token,
+              conference_type: nil
+            }
+            creator = DeviceCreator.new(params)
+
+            creator.create
+
+            expect(Device.count).to eq(1)
+            device = Device.last
+            expect(device.token).to eq(token)
+            expect(device.conference_type).to eq("ruby")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We will be supporting multiple conferences with this app.

- Add `type` to `Conference`.
- Add `conference_type` to `Device`.
- `api/v1/conferences` only serves Ruby Conferences.
